### PR TITLE
Handle case where fyle->idx > fyle->len correctly

### DIFF
--- a/src/filesys_c.c
+++ b/src/filesys_c.c
@@ -647,7 +647,7 @@ STRLEN_RANGE      *outlen;
 
     *outlen = 0;
     do {
-        if (fyle->idx == fyle->len) {
+        if (fyle->idx >= fyle->len) {
             fyle->len = read(fyle->fd, fyle->buf, MAX_STRLEN);
             fyle->idx = 0;
         }


### PR DESCRIPTION
Ensure that a fresh buffer is read whenever idx is past the end of the current buffer len.

Prior to this fix, this bug prevented submitting command sequences via stdin, like this:
```
rm new_file && ( echo "i/inserted string/" | ludwig new_file )
```

Previously this would have resulted in an empty file, as the command sequence
would not have been read from stdin.  On completion, the contents of `new_file`
would have been empty.

Now the command sequence is read correctly, and the contents of `new_file`
will contain `"inserted string\n"`.